### PR TITLE
rename package for npmjs package name guidelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nem-nodejs-sdk",
+  "name": "nem-sdk",
   "version": "1.0.0",
   "description": "",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "NEM-Library",
+  "name": "nem-nodejs-sdk",
   "version": "1.0.0",
   "description": "",
   "main": "build/index.js",


### PR DESCRIPTION
Hello,

in order to publish this package to https://npmjs.com , I needed to rename the package because they accept only lowercase. I decided to name the package "nem-nodejs-sdk" but if you prefer another name I would be up to modify this PR with the name you provide.

The package is now installable through npm directly with :

    $ npm require nem-nodejs-sdk

The URL to the package on npmjs is here: https://www.npmjs.com/package/nem-nodejs-sdk