### PR TITLE
implement postinstall script in package.json for automatic build upon install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem-sdk",
-  "version": "1.0.1-patch3",
+  "version": "1.0.1-patch4",
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem-sdk",
-  "version": "1.0.1",
+  "version": "1.0.1-patch1",
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem-sdk",
-  "version": "1.0.1-patch2",
+  "version": "1.0.1-patch3",
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem-sdk",
-  "version": "1.0.1-patch1",
+  "version": "1.0.1-patch2",
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "nem-sdk",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src --presets babel-preset-es2015 --out-dir build --source-maps",
     "browserify": "mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "npm run build"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel src --presets babel-preset-es2015 --out-dir build --source-maps",
+    "build": "./node_modules/babel-cli/bin/babel.js src --presets babel-preset-es2015 --out-dir build --source-maps",
     "browserify": "mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
     "prepublish": "npm run build",
     "postinstall": "npm run build"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "NEM Developer Kit for Node.js and the browser",
   "main": "build/index.js",
   "scripts": {
+    "clean": "rm -rf dist/ build/*",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/babel-cli/bin/babel.js src --presets babel-preset-es2015 --out-dir build --source-maps",
-    "browserify": "mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
-    "prepublish": "npm run build",
-    "postinstall": "npm run build"
+    "build": "babel src --presets babel-preset-es2015 --out-dir build --source-maps",
+    "browserify": "npm run build && mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
+    "prepublish": "npm run build"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "clean": "rm -rf dist/ build/*",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src --presets babel-preset-es2015 --out-dir build --source-maps",
-    "browserify": "npm run build && mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
-    "prepublish": "npm run build"
+    "browserify": "mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
+    "postinstall": "npm run build && npm run browserify"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "babel-cli": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "crypto-js": "3.1.9-1",


### PR DESCRIPTION
hello as discussed in private i have checked what was needed for an automatic build and it seems the postinstall script does exactly what we want. 

When users now run "npm install nem-sdk" it will first install all dependencies (babel, etc.), then build the SDK into the build/ directory (which has also been force added to the repo)

Greets!