### PR TITLE
add uglify-js and integrate to package versioning process

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "babel-preset-es2015": "^6.6.0",
     "crypto-js": "3.1.9-1",
     "jquery": "3.0.0",
-    "request": "2.81.0",
+    "request": "2.81.0"
+  },
+  "devDependencies": {
     "browserify": "14.1.0",
     "through": "2.3.8",
     "duplexer": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel src --presets babel-preset-es2015 --out-dir build --source-maps",
     "browserify": "mkdir -p dist && browserify -r through -r duplexer -r ./build/index.js:nem-sdk > dist/nem-sdk.js",
-    "version": "npm run build && npm run browserify && git add -A dist/",
+    "minify": "uglifyjs dist/nem-sdk.js > dist/nem-sdk.min.js",
+    "version": "npm run build && npm run browserify && npm run minify && git add -A dist/",
     "postversion": "git push origin master && git push --tags",
     "postinstall": "npm run build"
   },
@@ -28,6 +29,7 @@
   "devDependencies": {
     "browserify": "14.1.0",
     "through": "2.3.8",
-    "duplexer": "0.1.1"
+    "duplexer": "0.1.1",
+    "uglify-js": "~1.3.5"
   }
 }


### PR DESCRIPTION
this PR contains 2 changes in the package.json:

1) move browserify, through and duplexer dependencies to devDependencies. This is because those are only needed for _building_ the SDK. (difference between dependencies and devDependencies explained here: http://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies#22004559 )

2) add uglify-js dependency and "minify" npm script + integrate new script in versioning process.

After you have merged this PR you can version to 1.0.1-RC4 with npm and it will build + browserify + minify the SDK and automatically commit & push the first minified files. I didn't do the versioning part because I don't want people to think I take over the whole SDK since this is a complete minified file I believe the versioning process should be left to @QuantumMechanics 

Great weekend ahead! 