### PR TITLE
implemented importance transfer transactions functions

### DIFF
--- a/src/model/objects.js
+++ b/src/model/objects.js
@@ -102,7 +102,21 @@ let mosaicDefinitionTransaction = {}
 
 let namespaceProvisionTransaction = {}
 
-let importanceTransferTransaction = {}
+/**
+ * An un-prepared importance transfer transaction object
+ *
+ * @return {object}
+ */
+let importanceTransferTransaction(remoteAccount,mode) = {
+    return={
+            "isMultisig": false,
+            "multisigAccount" : "",
+            "isEncrypted" : false,
+            "remoteAccount": remoteAccount,
+            "mode": mode
+        }
+
+}
 
 /**
  * Get an empty object 
@@ -159,6 +173,9 @@ let create = function(objectName) {
             break;
         case "transferTransaction":
             return transferTransaction;
+            break;
+        case "importanceTransferTransaction":
+            return importanceTransferTransaction;
             break;
         default:
             return {};


### PR DESCRIPTION
This is based on code I used to create an importance transfer with nem-sdk.
I expect it to need some corrections, but it should be a good start.

I haven't been able to test this version integrated to nem-sdk but when working it should allow code of this kind:
```
var importanceTransaction = nem.model.objects.create("importanceTransferTransaction")(remoteAccount, mode);

var common = nem.model.objects.get("common");
common.privateKey = initiator_private_key;

// supports multisig
importanceTransaction.isMultisig= true;
importanceTransaction.multisigAccount=real_sender;

var transactionEntity = nem.model.transactions.prepare("importanceTransferTransaction")(common, importanceTransaction, nem.model.network.data.testnet.id);

// FIXME: Shouldn't this be set automatically somehow?
transactionEntity.fee=26000000

var kp = nem.crypto.keyPair.create(common.privateKey);
var serialized = nem.utils.serialization.serializeTransaction(transactionEntity);
var signature = kp.sign(serialized);

var result = {
                'data': nem.utils.convert.ua2hex(serialized),
                'signature': signature.toString()
            };
```

