### PR TITLE
add txId optional parameter for outgoingTransactions, incomingTransactions and allTransactions in com.requests.account

### DIFF
--- a/src/com/requests/account.js
+++ b/src/com/requests/account.js
@@ -75,12 +75,21 @@ let harvestedBlocks = function(endpoint, address){
  */
 let incomingTransactions = function(endpoint, address, txHash, txId){
 	return new Promise((resolve, reject) => {
+		var params = {'address': address};
+
+		// add optional parameters
+		if (txHash)
+			params['hash'] = txHash;
+
+		if (txId)
+			params['id'] = txId;
+
 		// Configure the request
 		var options = {
 		    url: Helpers.formatEndpoint(endpoint) + '/account/transfers/incoming',
 		    method: 'GET',
 		    headers: urlEncodedHeader,
-		    qs: {'address': address, 'hash': txHash || '', 'id': txId || ''}
+		    qs: params
 		}
 
 		// Start the request
@@ -106,12 +115,21 @@ let incomingTransactions = function(endpoint, address, txHash, txId){
  */
 let outgoingTransactions = function(endpoint, address, txHash, txId){
 	return new Promise((resolve, reject) => {
+		var params = {'address': address};
+
+		// add optional parameters
+		if (txHash)
+			params['hash'] = txHash;
+
+		if (txId)
+			params['id'] = txId;
+
 		// Configure the request
 		var options = {
 		    url: Helpers.formatEndpoint(endpoint) + '/account/transfers/outgoing',
 		    method: 'GET',
 		    headers: urlEncodedHeader,
-		    qs: {'address': address, 'hash': txHash || '', 'id': txId || ''}
+		    qs: params
 		}
 
 		// Start the request
@@ -398,12 +416,22 @@ let mosaics = function(endpoint, address){
  */
 let allTransactions = function(endpoint, address, txHash, txId){
 	return new Promise((resolve, reject) => {
+
+		var params = {'address': address};
+
+		// add optional parameters
+		if (txHash)
+			params['hash'] = txHash;
+
+		if (txId)
+			params['id'] = txId;
+
 		// Configure the request
 		var options = {
 		    url: Helpers.formatEndpoint(endpoint) + '/account/transfers/all',
 		    method: 'GET',
 		    headers: urlEncodedHeader,
-		    qs: { 'address': address, 'hash': txHash || '', 'id': txId || '' }
+		    qs: params
 		}
 
 		// Start the request

--- a/src/com/requests/account.js
+++ b/src/com/requests/account.js
@@ -69,17 +69,18 @@ let harvestedBlocks = function(endpoint, address){
  * @param {object} endpoint - An NIS endpoint object
  * @param {string} address - An account address
  * @param {string} txHash - A starting hash for search (optional)
+ * @param {string} txId - A starting ID (optional)
  *
  * @return {array} - An array of [TransactionMetaDataPair]{@link http://bob.nem.ninja/docs/#transactionMetaDataPair} objects
  */
-let incomingTransactions = function(endpoint, address, txHash){
+let incomingTransactions = function(endpoint, address, txHash, txId){
 	return new Promise((resolve, reject) => {
 		// Configure the request
 		var options = {
 		    url: Helpers.formatEndpoint(endpoint) + '/account/transfers/incoming',
 		    method: 'GET',
 		    headers: urlEncodedHeader,
-		    qs: {'address': address, 'hash': txHash}
+		    qs: {'address': address, 'hash': txHash || '', 'id': txId || ''}
 		}
 
 		// Start the request
@@ -99,17 +100,18 @@ let incomingTransactions = function(endpoint, address, txHash){
  * @param {object} endpoint - An NIS endpoint object
  * @param {string} address - An account address
  * @param {string} txHash - A starting hash for search (optional)
+ * @param {string} txId - A starting ID (optional)
  *
  * @return {array} - An array of [TransactionMetaDataPair]{@link http://bob.nem.ninja/docs/#transactionMetaDataPair} objects
  */
-let outgoingTransactions = function(endpoint, address, txHash){
+let outgoingTransactions = function(endpoint, address, txHash, txId){
 	return new Promise((resolve, reject) => {
 		// Configure the request
 		var options = {
 		    url: Helpers.formatEndpoint(endpoint) + '/account/transfers/outgoing',
 		    method: 'GET',
 		    headers: urlEncodedHeader,
-		    qs: {'address': address, 'hash': txHash}
+		    qs: {'address': address, 'hash': txHash || '', 'id': txId || ''}
 		}
 
 		// Start the request
@@ -390,17 +392,18 @@ let mosaics = function(endpoint, address){
  * @param {object} endpoint - An NIS endpoint object
  * @param {string} address - An account address
  * @param {string} txHash - A starting hash (optional)
+ * @param {string} txId - A starting ID (optional)
  *
  * @return {array} - An array of [TransactionMetaDataPair]{@link http://bob.nem.ninja/docs/#transactionMetaDataPair} objects
  */
-let allTransactions = function(endpoint, address, txHash){
+let allTransactions = function(endpoint, address, txHash, txId){
 	return new Promise((resolve, reject) => {
 		// Configure the request
 		var options = {
 		    url: Helpers.formatEndpoint(endpoint) + '/account/transfers/all',
 		    method: 'GET',
 		    headers: urlEncodedHeader,
-		    qs: { 'address': address, 'hash': txHash || '' }
+		    qs: { 'address': address, 'hash': txHash || '', 'id': txId || '' }
 		}
 
 		// Start the request


### PR DESCRIPTION

I added the txId because *all* NEM nodes support the *id* field whereas the *hash* field seems to be supported only by a subset of the NEM nodes. Therefore I think it is important to provide the option of using the *id* field.

Take care :)