### PR TITLE
NEM-NANOWALLET-527 - unable to send more than 1000 mosaics - fix for …

### DIFF
--- a/src/model/fees.js
+++ b/src/model/fees.js
@@ -129,7 +129,7 @@ let calculateMosaics = function(multiplier, mosaics, attachedMosaics) {
         } else {
             let maxMosaicQuantity = 9000000000000000;
             let totalMosaicQuantity = supply * Math.pow(10, divisibility)
-            supplyRelatedAdjustment = Math.floor(0.8 * Math.log(maxMosaicQuantity / totalMosaicQuantity));
+            supplyRelatedAdjustment = Math.floor(0.8 * Math.log(Math.floor(maxMosaicQuantity / totalMosaicQuantity)));
             let numNem = calculateXemEquivalent(multiplier, quantity, supply, divisibility);
             // Using Math.ceil below because xem equivalent returned is sometimes a bit lower than it should
             // Ex: 150'000 of nem:xem gives 149999.99999999997


### PR DESCRIPTION
Fix for issue:
https://github.com/NemProject/NanoWallet/issues/527

In nanowallet generated main.js code I've found twice this code but there is also third one.
createWithMosaics function with pretty same code but I can't locate it.

```
    static createWithMosaics(timeWindow, recipient, mosaics, message) {
...
                const quantity = mosaic.amount;
                const maxMosaicQuantity = 9000000000000000;
                const totalMosaicQuantity = mosaic.properties.initialSupply * Math.pow(10, mosaic.properties.divisibility);
                const supplyRelatedAdjustment = Math.floor(0.8 * Math.log(Math.floor(maxMosaicQuantity / totalMosaicQuantity)));
                const xemFee = Math.min(25, quantity * 900000 / mosaic.properties.initialSupply);
                fee += 0.05 * Math.max(1, xemFee - supplyRelatedAdjustment) * 1000000;
...
    }

```