### PR TITLE
Send publicKey in HEX format

### DIFF
--- a/src/model/address.js
+++ b/src/model/address.js
@@ -81,7 +81,8 @@ let b32decode = function(s) {
 * @return {string} - The NEM address
 */
 let toAddress = function(publicKey, networkId) {
-    let binPubKey = CryptoJS.enc.Hex.parse(publicKey);
+    const publicKeyHex = publicKey.toString('hex');
+    let binPubKey = CryptoJS.enc.Hex.parse(publicKeyHex);
     let hash = CryptoJS.SHA3(binPubKey, {
         outputLength: 256
     });


### PR DESCRIPTION
There is a critical error in the package that I have found several days ago. NEM addresses are generated incorrect. 

Below you can see a code that reproduce a bug in the package:
```
const nemSdk = require('./src');

const countAddress = 10;
let i = 0;
while (i < countAddress) {
    const rBytes = nemSdk.default.crypto.nacl.randomBytes(32);
    const privateKey = nemSdk.default.utils.convert.ua2hex(rBytes);
    const keyPair = nemSdk.default.crypto.keyPair.create(privateKey);
    const { publicKey } = keyPair;
    const address = nemSdk.default.model.address.toAddress(publicKey, 104);
    console.log('address', address);
    i++;
}
```

And also I attach a screenshot where you can see the same generated addresses:
![screenshot_204](https://user-images.githubusercontent.com/11200149/51431624-c0d04180-1c3c-11e9-9d76-24426f559ee3.png)

I had to spend some time to find the error and I could. I decided to commit the fix because address might generate correct, didn't me ?

I attach another screenshot where you can see that XEM address are generated correct:
![screenshot_205](https://user-images.githubusercontent.com/11200149/51431653-43f19780-1c3d-11e9-8a79-8d4f768c3121.png)

If you don't believe me then you can start the script to make sure.

